### PR TITLE
[#169038151] Adds indent class

### DIFF
--- a/lib/htmltoword/version.rb
+++ b/lib/htmltoword/version.rb
@@ -1,3 +1,3 @@
 module Htmltoword
-  VERSION = '0.7.1'
+  VERSION = '0.7.2'
 end

--- a/lib/htmltoword/xslt/base.xslt
+++ b/lib/htmltoword/xslt/base.xslt
@@ -382,4 +382,12 @@
     </xsl:if>
   </xsl:template>
 
+  <xsl:template match="div[contains(concat(' ', @class, ' '), ' -ind ')]">
+    <xsl:variable name="ilvl" select="count(ancestor::ol) + count(ancestor::ul)"></xsl:variable>
+    <w:pPr>
+      <w:ind w:left="{720 * ($ilvl + 1)}"/>
+    </w:pPr>
+    <xsl:apply-templates/>
+  </xsl:template>
+
 </xsl:stylesheet>


### PR DESCRIPTION
The `-ind` selector will only work with lists for now, because of the variable `ilvl`. We can later change it to be compatible with all parents.